### PR TITLE
Introduce AdaptiveSampler

### DIFF
--- a/src/power.js
+++ b/src/power.js
@@ -9,15 +9,14 @@ class PowerRanker {
   /// @notice Construct an instance of a PowerRanker
   /// @param items:Set(str) The items being voted on
   /// @param numParticipants:int The number of participants
-  /// @param preferences:Array[{target:str, source:str, value:float}] The preferences of the participants
-  constructor ({ items, numParticipants, preferences, verbose = false }) {
+  constructor ({ items, numParticipants, verbose = false }) {
     assert(items.size >= 2, 'PowerRanker: Cannot rank less than two items');
 
     this.items = items;
+    this.numParticipants = numParticipants;
+    this.matrix = this._prepareMatrix(items, numParticipants);
+
     this.verbose = verbose;
-
-    this.matrix = this._toMatrix(items, preferences, numParticipants);
-
     this.log('Matrix initialized');
   }
 
@@ -26,39 +25,13 @@ class PowerRanker {
     if (this.verbose) { console.log(msg); }
   }
 
-  /// @notice Run the algorithm and return the results
-  /// @param d:float The damping factor, 1 means no damping
-  /// @param epsilon:float The precision at which to run the algorithm
-  /// @param nIter:int The maximum number of iterations to run the algorithm
-  /// @return rankings:Map(int => float) The rankings, with item mapped to result
-  run ({ d = 1, epsilon = 0.001, nIter = 1000 }) {
-    const weights = this._powerMethod(this.matrix, d, epsilon, nIter);
-    return this._applyLabels(this.items, weights);
-  }
-
-  // Internal
-
-  // O(items)
-  _applyLabels (items, eigenvector) {
-    const itemMap = this.#toitemMap(items);
-    assert(itemMap.size === eigenvector.length, 'Mismatched arguments!');
-    itemMap.forEach((ix, item) => itemMap.set(item, eigenvector[ix]));
-    return itemMap;
-  }
-
-  // O(preferences)
-  _toMatrix (items, preferences, numParticipants) { // [{ target, source, value }]
-    const n = items.size;
-    const itemMap = this.#toitemMap(items);
-
-    // Initialise the zero matrix;
-    let matrix = linAlg.Matrix.zero(n, n);
-
-    // Add implicit neutral preferences
-    const implicitPref = (1 / numParticipants) / 2; // Halve the value since used twice
-    matrix = matrix
-      .plusEach(1).minus(linAlg.Matrix.identity(n))
-      .mulEach(implicitPref).mulEach(numParticipants);
+  /// @notice Add preferences to the matrix
+  /// @dev Complexity is O(preferences.length)
+  /// @param preferences:Array[{target:str, source:str, value:float}] The preferences of the participants
+  addPreferences (preferences) { // [{ target, source, value }]
+    const matrix = this.matrix;
+    const itemMap = this.#toitemMap(this.items);
+    const implicitPref = this._getImplicitPref();
 
     // Add the preferences to the off-diagonals, removing the implicit neutral preference
     // Recall that value > 0.5 is flow towards, value < 0.5 is flow away
@@ -78,10 +51,45 @@ class PowerRanker {
 
     // Add the diagonals (sums of columns)
     this.#sumColumns(matrix).map((sum, ix) => matrix.data[ix][ix] = sum); // eslint-disable-line no-return-assign
+  }
+
+  /// @notice Run the algorithm and return the results
+  /// @param d:float The damping factor, 1 means no damping
+  /// @param epsilon:float The precision at which to run the algorithm
+  /// @param nIter:int The maximum number of iterations to run the algorithm
+  /// @return rankings:Map(int => float) The rankings, with item mapped to result
+  run ({ d = 1, epsilon = 0.001, nIter = 1000 }) {
+    const weights = this._powerMethod(this.matrix, d, epsilon, nIter);
+    return this._applyLabels(this.items, weights);
+  }
+
+  // Internal
+
+  // Complexity is O(items.length)
+  _applyLabels (items, eigenvector) {
+    const itemMap = this.#toitemMap(items);
+    assert(itemMap.size === eigenvector.length, 'Mismatched arguments!');
+    itemMap.forEach((ix, item) => itemMap.set(item, eigenvector[ix]));
+
+    return itemMap;
+  }
+
+  _prepareMatrix (items, numParticipants) {
+    const n = items.size;
+
+    // Initialise the zero matrix;
+    let matrix = linAlg.Matrix.zero(n, n);
+
+    // Add implicit neutral preferences
+    const implicitPref = this._getImplicitPref();
+    matrix = matrix
+      .plusEach(1).minus(linAlg.Matrix.identity(n))
+      .mulEach(implicitPref).mulEach(numParticipants);
+
     return matrix;
   }
 
-  // O(n^3)-ish
+  // Complexity is O(n^3)-ish
   _powerMethod (matrix, d, epsilon, nIter) {
     assert(matrix.rows === matrix.cols, 'Matrix must be square!');
     const n = matrix.rows;
@@ -112,6 +120,10 @@ class PowerRanker {
 
     this.log(`Eigenvector convergence after ${i} iterations`);
     return eigenvector.data[0];
+  }
+
+  _getImplicitPref () {
+    return (1 / this.numParticipants) / 2; // Halve the value since used twice
   }
 
   // Private

--- a/src/sampler.js
+++ b/src/sampler.js
@@ -1,0 +1,33 @@
+const assert = require('assert');
+
+class AdaptiveSampler {
+  variances; // Array[{a:str, b:str, variance:float}]
+
+  /// @notice Construct an instance of a AdaptiveSampler
+  /// @param variances:Array[{a:str, b:str, variance:float}] The variances
+  constructor ({ variances }) {
+    assert(variances.length >= 1, 'AdaptiveSampler: Cannot sample less than one pair');
+
+    this.sumVariance = 0;
+
+    // O(n)
+    this.variances = variances
+      .map(({ alpha, beta, variance }) => {
+        this.sumVariance += variance;
+        return { alpha, beta, cumSumVariance: this.sumVariance };
+      });
+  }
+
+  /// @notice Suggest a pair of items, proportional to the variance
+  /// @dev Result is non-deterministic
+  /// @return { a, b }: { str, str } The pair of items to vote on
+  samplePair () {
+    const threshold = Math.random() * this.sumVariance;
+
+    // cumSumVariance increases monotonically
+    return this.variances
+      .find(({ cumSumVariance }) => cumSumVariance >= threshold);
+  }
+}
+
+module.exports = AdaptiveSampler;

--- a/test/power.js
+++ b/test/power.js
@@ -15,90 +15,120 @@ describe('PowerRanker', () => {
   const numParticipants = 3;
   const d = 0.99;
 
-  it('can return uniform rankings implicitly', async () => {
-    const powerRanker = new PowerRanker({ items, numParticipants });
-    const rankings = powerRanker.run({ d });
+  describe('generating rankings', () => {
+    it('can return uniform rankings implicitly', async () => {
+      const powerRanker = new PowerRanker({ items, numParticipants });
+      const rankings = powerRanker.run({ d });
 
-    expect(rankings.get(a)).to.be.almost(0.3333333333333333);
-    expect(rankings.get(b)).to.be.almost(0.3333333333333333);
-    expect(rankings.get(c)).to.be.almost(0.3333333333333333);
+      expect(rankings.get(a)).to.be.almost(0.3333333333333333);
+      expect(rankings.get(b)).to.be.almost(0.3333333333333333);
+      expect(rankings.get(c)).to.be.almost(0.3333333333333333);
+    });
+
+    it('can use preferences to determine rankings', async () => {
+      const powerRanker = new PowerRanker({ items, numParticipants });
+
+      powerRanker.addPreferences([
+        { target: a, source: b, value: 1 },
+        { target: b, source: c, value: 1 },
+      ]);
+
+      const rankings = powerRanker.run({ d });
+
+      expect(rankings.get(a)).to.be.almost(0.5038945471248252);
+      expect(rankings.get(b)).to.be.almost(0.31132043857597014);
+      expect(rankings.get(c)).to.be.almost(0.18478501429920438);
+    });
+
+    it('can dampen rankings', async () => {
+      const powerRanker = new PowerRanker({ items, numParticipants });
+
+      // Same preferences as above
+      powerRanker.addPreferences([
+        { target: a, source: b, value: 1 },
+        { target: b, source: c, value: 1 },
+      ]);
+
+      const rankings = powerRanker.run({ d: 0.5 });
+
+      expect(rankings.get(a)).to.be.almost(0.39569727579752584);
+      expect(rankings.get(b)).to.be.almost(0.3425397745768228);
+      expect(rankings.get(c)).to.be.almost(0.26176294962565094);
+    });
+
+    it('can use preferences to determine mild rankings', async () => {
+      const powerRanker = new PowerRanker({ items, numParticipants });
+
+      powerRanker.addPreferences([
+        { target: a, source: b, value: 0.7 },
+        { target: b, source: c, value: 0.7 },
+      ]);
+
+      const rankings = powerRanker.run({ d });
+
+      expect(rankings.get(a)).to.be.almost(0.4670116340772533);
+      expect(rankings.get(b)).to.be.almost(0.31890095736170976);
+      expect(rankings.get(c)).to.be.almost(0.21408740856103664);
+    });
+
+    it('can use preferences to determine complex rankings', async () => {
+      const powerRanker = new PowerRanker({ items, numParticipants });
+
+      powerRanker.addPreferences([
+        { target: a, source: b, value: 0.7 },
+        { target: a, source: c, value: 0.3 },
+        { target: b, source: c, value: 0.3 },
+      ]);
+
+      const rankings = powerRanker.run({ d });
+
+      expect(rankings.get(a)).to.be.almost(0.25572135860019535);
+      expect(rankings.get(b)).to.be.almost(0.1411003954995132);
+      expect(rankings.get(c)).to.be.almost(0.6031782459002907);
+    });
+
+    it('can handle circular rankings', async () => {
+      const powerRanker = new PowerRanker({ items, numParticipants });
+
+      powerRanker.addPreferences([
+        { target: a, source: b, value: 1 },
+        { target: b, source: c, value: 1 },
+        { target: c, source: a, value: 1 },
+      ]);
+
+      const rankings = powerRanker.run({ d });
+
+      expect(rankings.get(a)).to.be.almost(0.3333333333333333);
+      expect(rankings.get(b)).to.be.almost(0.3333333333333333);
+      expect(rankings.get(c)).to.be.almost(0.3333333333333333);
+    });
   });
 
-  it('can use preferences to determine rankings', async () => {
-    const powerRanker = new PowerRanker({ items, numParticipants });
+  describe('generating variances', () => {
+    it('can get variances', async () => {
+      const powerRanker = new PowerRanker({ items, numParticipants: 0 });
 
-    powerRanker.addPreferences([
-      { target: a, source: b, value: 1 },
-      { target: b, source: c, value: 1 },
-    ]);
+      let variances;
 
-    const rankings = powerRanker.run({ d });
+      variances = powerRanker.getVariances();
+      expect(variances.length).to.equal(3);
+      expect(variances[0].variance).to.equal(1 / 12); // Beta(1, 1)
+      expect(variances[0].alpha).to.equal(a);
+      expect(variances[0].beta).to.equal(b);
 
-    expect(rankings.get(a)).to.be.almost(0.5038945471248252);
-    expect(rankings.get(b)).to.be.almost(0.31132043857597014);
-    expect(rankings.get(c)).to.be.almost(0.18478501429920438);
-  });
+      powerRanker.addPreferences([
+        { target: a, source: b, value: 1 },
+        { target: b, source: a, value: 1 },
+        { target: a, source: c, value: 1 },
+        { target: c, source: a, value: 0 },
+        { target: b, source: c, value: 0 },
+        { target: c, source: b, value: 1 },
+      ]);
 
-  it('can dampen rankings', async () => {
-    const powerRanker = new PowerRanker({ items, numParticipants });
-
-    // Same preferences as above
-    powerRanker.addPreferences([
-      { target: a, source: b, value: 1 },
-      { target: b, source: c, value: 1 },
-    ]);
-
-    const rankings = powerRanker.run({ d: 0.5 });
-
-    expect(rankings.get(a)).to.be.almost(0.39569727579752584);
-    expect(rankings.get(b)).to.be.almost(0.3425397745768228);
-    expect(rankings.get(c)).to.be.almost(0.26176294962565094);
-  });
-
-  it('can use preferences to determine mild rankings', async () => {
-    const powerRanker = new PowerRanker({ items, numParticipants });
-
-    powerRanker.addPreferences([
-      { target: a, source: b, value: 0.7 },
-      { target: b, source: c, value: 0.7 },
-    ]);
-
-    const rankings = powerRanker.run({ d });
-
-    expect(rankings.get(a)).to.be.almost(0.4670116340772533);
-    expect(rankings.get(b)).to.be.almost(0.31890095736170976);
-    expect(rankings.get(c)).to.be.almost(0.21408740856103664);
-  });
-
-  it('can use preferences to determine complex rankings', async () => {
-    const powerRanker = new PowerRanker({ items, numParticipants });
-
-    powerRanker.addPreferences([
-      { target: a, source: b, value: 0.7 },
-      { target: a, source: c, value: 0.3 },
-      { target: b, source: c, value: 0.3 },
-    ]);
-
-    const rankings = powerRanker.run({ d });
-
-    expect(rankings.get(a)).to.be.almost(0.25572135860019535);
-    expect(rankings.get(b)).to.be.almost(0.1411003954995132);
-    expect(rankings.get(c)).to.be.almost(0.6031782459002907);
-  });
-
-  it('can handle circular rankings', async () => {
-    const powerRanker = new PowerRanker({ items, numParticipants });
-
-    powerRanker.addPreferences([
-      { target: a, source: b, value: 1 },
-      { target: b, source: c, value: 1 },
-      { target: c, source: a, value: 1 },
-    ]);
-
-    const rankings = powerRanker.run({ d });
-
-    expect(rankings.get(a)).to.be.almost(0.3333333333333333);
-    expect(rankings.get(b)).to.be.almost(0.3333333333333333);
-    expect(rankings.get(c)).to.be.almost(0.3333333333333333);
+      variances = powerRanker.getVariances();
+      expect(variances[0].variance).to.equal(1 / 20); // Beta(2, 2)
+      expect(variances[1].variance).to.equal(3 / 80); // Beta(3, 1)
+      expect(variances[2].variance).to.equal(3 / 80); // Beta(1, 3)
+    });
   });
 });

--- a/test/power.js
+++ b/test/power.js
@@ -16,7 +16,7 @@ describe('PowerRanker', () => {
   const d = 0.99;
 
   it('can return uniform rankings implicitly', async () => {
-    const powerRanker = new PowerRanker({ items, numParticipants, preferences: [] });
+    const powerRanker = new PowerRanker({ items, numParticipants });
     const rankings = powerRanker.run({ d });
 
     expect(rankings.get(a)).to.be.almost(0.3333333333333333);
@@ -25,12 +25,13 @@ describe('PowerRanker', () => {
   });
 
   it('can use preferences to determine rankings', async () => {
-    const preferences = [
+    const powerRanker = new PowerRanker({ items, numParticipants });
+
+    powerRanker.addPreferences([
       { target: a, source: b, value: 1 },
       { target: b, source: c, value: 1 },
-    ];
+    ]);
 
-    const powerRanker = new PowerRanker({ items, numParticipants, preferences });
     const rankings = powerRanker.run({ d });
 
     expect(rankings.get(a)).to.be.almost(0.5038945471248252);
@@ -39,13 +40,14 @@ describe('PowerRanker', () => {
   });
 
   it('can dampen rankings', async () => {
+    const powerRanker = new PowerRanker({ items, numParticipants });
+
     // Same preferences as above
-    const preferences = [
+    powerRanker.addPreferences([
       { target: a, source: b, value: 1 },
       { target: b, source: c, value: 1 },
-    ];
+    ]);
 
-    const powerRanker = new PowerRanker({ items, numParticipants, preferences });
     const rankings = powerRanker.run({ d: 0.5 });
 
     expect(rankings.get(a)).to.be.almost(0.39569727579752584);
@@ -54,12 +56,13 @@ describe('PowerRanker', () => {
   });
 
   it('can use preferences to determine mild rankings', async () => {
-    const preferences = [
+    const powerRanker = new PowerRanker({ items, numParticipants });
+
+    powerRanker.addPreferences([
       { target: a, source: b, value: 0.7 },
       { target: b, source: c, value: 0.7 },
-    ];
+    ]);
 
-    const powerRanker = new PowerRanker({ items, numParticipants, preferences });
     const rankings = powerRanker.run({ d });
 
     expect(rankings.get(a)).to.be.almost(0.4670116340772533);
@@ -68,13 +71,14 @@ describe('PowerRanker', () => {
   });
 
   it('can use preferences to determine complex rankings', async () => {
-    const preferences = [
+    const powerRanker = new PowerRanker({ items, numParticipants });
+
+    powerRanker.addPreferences([
       { target: a, source: b, value: 0.7 },
       { target: a, source: c, value: 0.3 },
       { target: b, source: c, value: 0.3 },
-    ];
+    ]);
 
-    const powerRanker = new PowerRanker({ items, numParticipants, preferences });
     const rankings = powerRanker.run({ d });
 
     expect(rankings.get(a)).to.be.almost(0.25572135860019535);
@@ -83,13 +87,14 @@ describe('PowerRanker', () => {
   });
 
   it('can handle circular rankings', async () => {
-    const preferences = [
+    const powerRanker = new PowerRanker({ items, numParticipants });
+
+    powerRanker.addPreferences([
       { target: a, source: b, value: 1 },
       { target: b, source: c, value: 1 },
       { target: c, source: a, value: 1 },
-    ];
+    ]);
 
-    const powerRanker = new PowerRanker({ items, numParticipants, preferences });
     const rankings = powerRanker.run({ d });
 
     expect(rankings.get(a)).to.be.almost(0.3333333333333333);

--- a/test/sampler.js
+++ b/test/sampler.js
@@ -1,0 +1,40 @@
+const { expect } = require('chai');
+
+const chai = require('chai');
+const chaiAsPromised = require('chai-as-promised');
+const chaiAlmost = require('chai-almost');
+
+chai.use(chaiAsPromised);
+chai.use(chaiAlmost());
+
+const PowerRanker = require('../src/power');
+const AdaptiveSampler = require('../src/sampler');
+
+describe('AdaptiveSampler', () => {
+  const [ a, b, c ] = [ 'a', 'b', 'c' ];
+  const items = new Set([ a, b, c ]);
+
+  describe('suggesting pairs', () => {
+    it('can correctly calculate cumulative variance', async () => {
+      const powerRanker = new PowerRanker({ items });
+      const adaptiveSampler = new AdaptiveSampler({ variances: powerRanker.getVariances() });
+
+      expect(adaptiveSampler.variances.slice(-1)[0].cumSumVariance)
+        .to.equal(adaptiveSampler.sumVariance);
+    });
+
+    it('can sample pairs', async () => {
+      const powerRanker = new PowerRanker({ items });
+      const adaptiveSampler = new AdaptiveSampler({ variances: powerRanker.getVariances() });
+
+      // Not an ideal test, function is probabilistic
+      for (let i = 0; i < 3; i++) {
+        const sample = adaptiveSampler.samplePair();
+
+        expect(sample.alpha).to.be.oneOf([ a, b, c ]);
+        expect(sample.beta).to.be.oneOf([ a, b, c ]);
+        expect(sample.cumSumVariance).to.be.lte(adaptiveSampler.sumVariance);
+      }
+    });
+  });
+});


### PR DESCRIPTION
Closes #2 

1. Re-architects `PowerRanker` to allow pairs to be supplied continually
2. Supports generation of per-pair "variances" based on the posterior Beta distribution
3. Introduce `AdaptiveSampler` to sample random pairs proportional to variance